### PR TITLE
Additions to ignore-list-contains.csv

### DIFF
--- a/criteria/ignore-list-contains.csv
+++ b/criteria/ignore-list-contains.csv
@@ -11,3 +11,11 @@ drtest,other
 pebblebeach,staging and development
 evpneast,authentication
 evpnwest,authentication
+cdn,asset server
+ftp,asset server
+alpha,staging and development
+beta,staging and development
+preprod,staging and development
+sandbox,staging and development
+sbx,staging and development
+sit,staging and development


### PR DESCRIPTION
Recommend adding 'alpha', 'beta', 'preprod', 'sandbox', 'sbx', and 'sit' (System Integration Testing) to this list to help filter out common naming patterns for other types of testing environments.

Can also add 'cdn' and 'ftp' to filter out those types of asset servers.