### PR TITLE
Adding NASA items to ignore-list-begins.csv

### DIFF
--- a/criteria/ignore-list-begins.csv
+++ b/criteria/ignore-list-begins.csv
@@ -149,3 +149,19 @@ app.fossil.energy.gov,application
 app.ntsb.gov,application
 apps.fema.gov,application
 4innovation-impl.cms.gov,staging
+beta-api.urs.eosdis.nasa.gov, staging and development
+beta.ciencia.nasa.gov, staging and development
+beta.nasa.gov, staging and development
+beta.science.nasa.gov, staging and development
+beta.urs.eosdis.nasa.gov, staging and development
+alpha-api.urs.eosdis.nasa.gov, staging and development
+alpha.urs.eosdis.nasa.gov, staging and development
+auth.launchpad.nasa.gov, authentication
+authfs.launchpad.nasa.gov, authentication
+authfs1.launchpad.nasa.gov, authentication
+api.globe.gov, endpoint
+api.launchpad.nasa.gov, endpoint
+images-api.nasa.gov, endpoint
+ssd-api.jpl.nasa.gov, endpoint
+targetapimsl.hi.jpl.nasa.gov, endpoint
+technology-api.ndc.nasa.gov, endpoint


### PR DESCRIPTION
Adding a few known staging/dev, authentication and API endpoints to the list.

If it wouldn't adversely affect other agencies' domain naming patterns (it wouldn't for NASA), could also just blanket-ignore all URLs starting with 'alpha', 'beta', and/or 'auth'.