### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/build-finalurl-list.yml
+++ b/.github/workflows/build-finalurl-list.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "30 20 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   my-job:
     name: Checkout, build, and run final URL list builder

--- a/.github/workflows/build-finalurl-list.yml
+++ b/.github/workflows/build-finalurl-list.yml
@@ -6,13 +6,12 @@ on:
   schedule:
     - cron: "30 20 * * *"
 
-permissions:
-  contents: write
-
 jobs:
   my-job:
     name: Checkout, build, and run final URL list builder
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/build-list-js.yml
+++ b/.github/workflows/build-list-js.yml
@@ -6,13 +6,12 @@ on:
   schedule:
     - cron: "15 20 * * *"
 
-permissions:
-  contents: write
-
 jobs:
   my-job:
     name: Checkout, build, and run indexer application
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/build-list-js.yml
+++ b/.github/workflows/build-list-js.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "15 20 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   my-job:
     name: Checkout, build, and run indexer application

--- a/.github/workflows/build-mil-list.yml
+++ b/.github/workflows/build-mil-list.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "40 20 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   my-job:
     name: Checkout, build, and run .mil domain list builder

--- a/.github/workflows/build-mil-list.yml
+++ b/.github/workflows/build-mil-list.yml
@@ -6,13 +6,12 @@ on:
   schedule:
     - cron: "40 20 * * *"
 
-permissions:
-  contents: write
-
 jobs:
   my-job:
     name: Checkout, build, and run .mil domain list builder
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to:
  - `.github/workflows/build-finalurl-list.yml`
  - `.github/workflows/build-list-js.yml`
  - `.github/workflows/build-mil-list.yml`
- Set `contents: write` because each workflow uses `git-auto-commit-action` to commit generated list updates.

## Why
Declaring explicit token scopes resolves missing-permissions findings and documents intended write access for scheduled automation.