### PR TITLE
Pin actions/github-script to SHA hash

### DIFF
--- a/.github/workflows/build-list-js.yml
+++ b/.github/workflows/build-list-js.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.SITE_SCANNING_ISSUE_REPO_TOKEN }}
           script: |


### PR DESCRIPTION
Pin 1 more dependency to SHA hash in prep of turning on SHA pinning enforcement rule.

Related: https://github.com/GSA/site-scanning/issues/1900